### PR TITLE
Trigger Builds with Circle API v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,13 +245,13 @@ handler.on( 'pull_request', function ( event ) {
         } )
         .then ( function () {
 
-            const triggerBuildURL = `https://circleci.com/api/v1.1/project/github/${ wpDesktopProject }/tree/${ wpDesktopBranchName }?circle-token=${ process.env.CIRCLECI_SECRET}`;
+            const triggerBuildURL = `https://circleci.com/api/v2/project/github/${ wpDesktopProject }/pipeline`;
 
             const sha = event.payload.pull_request.head.sha;
 
             const buildParameters = {
-                build_parameters: {
-                    BRANCHNAME: wpDesktopBranchName,
+                branch: wpDesktopBranchName,
+                parameters: {
                     sha: sha,
                     CALYPSO_HASH: sha,
                     pullRequestNum: pullRequestNum,
@@ -260,6 +260,9 @@ handler.on( 'pull_request', function ( event ) {
             };
             // POST to CircleCI to initiate the build
             return request.post( {
+                auth: {
+                    username: `${ process.env.CIRCLECI_SECRET }`
+                },
                 headers: { 'content-type': 'application/json', accept: 'application/json' },
                 url: triggerBuildURL,
                 body: JSON.stringify( buildParameters )


### PR DESCRIPTION
### Description

wp-desktop now uses Circle Config v2.1, which is required to support native builds on all platforms (Mac, Linux and Windows). However, this update has broken canary builds as a result of the v1.1 API not being able to support v2.1 Config ([ref](https://discuss.circleci.com/t/2-1-requires-pipelines-but-pipelines-are-enabled-in-project-settings/30484/7)).

```
Configuration version 2.1 requires the "Enable Pipelines" project setting. Enable pipelines under Project Settings -> Advanced Settings. In order to retrigger pipelines, you must push a new commit.
``` 

We now need to trigger builds with the v2 API, which restores the canary build process used in wp-calypso.

A corresponding update has been made to wp-desktop's config in order to pass build parameters from the API call to the wp-desktop pipeline.

### How Has This Been Tested

I verified that the v2 API triggers builds with the following curl call, where the `CALYPSO_HASH` corresponds to a currently outstanding calypso PR ([link](https://github.com/Automattic/wp-calypso/pull/39258)).

```
curl -u $CIRCLE_TOKEN: -d '{ "branch":"add-circle-v2-api-build-trigger-support", "parameters": { "sha":"59f85838e401f309e0246f9afd727a9f3927652b","CALYPSO_HASH":"59f85838e401f309e0246f9afd727a9f3927652b","pullRequestNum":"39258","calypsoProject":"Automattic/wp-calypso" } }' -H "Content-Type: application/json" -H "accept: application/json" https://circleci.com/api/v2/project/github/Automattic/wp-desktop/pipeline
```

Confirmed that the job builds successfully, and also uses the correct overriden `CALYPSO_HASH` that we inject via the build trigger:

```
Submodule 'wp-calypso' (https://github.com/Automattic/wp-calypso.git) registered for path 'calypso'
Cloning into '/home/circleci/wp-desktop/calypso'...
Submodule path 'calypso': checked out 'd5c48ed09da53a652284db08e97544301113d8bd'
Previous HEAD position was d5c48ed09d... Add EDITOR_IFRAME_LOADED event (#38986)
HEAD is now at 59f85838e4... Add support for erroring out when the site is not supported for migration
// ...
```

### v2 API Notes

- Triggering a new build ([ref](https://circleci.com/docs/api/v2/#trigger-a-new-pipeline))
- Authentication ([ref](https://circleci.com/docs/api/v2/#authentication)) (although the docs here indicate that a query parameter can be used, that doesn't seem to be the case. The only way I could get this to work was with the `username` parameter.)