### PR TITLE
Remove pullRequestNum from desktop payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,7 +254,6 @@ handler.on( 'pull_request', function ( event ) {
                 parameters: {
                     sha: sha,
                     CALYPSO_HASH: sha,
-                    pullRequestNum: pullRequestNum,
                     calypsoProject: calypsoProject
                 }
             };


### PR DESCRIPTION
### Description

It seems the Circle v2 API and/or the Circle Config v2.1 environment has problems resolving integer parameters. Have tried setting the parameter's `type` field in wp-desktop config.yml to `integer` and `string` with no success:
    
> Type error for argument pullRequestNum: expected type: string, actual value: "39001" (type integer)
    
> Type error for argument pullRequestNum: expected type: integer, actual value: "39001" (type string)
   
The above error results in the canary build job being blocked/unable to build. The build job will error out if a parameter in the sender's payload is not defined in the receiver's config.yml file, so we need to remove it from both the sending and receiving code. See corresponding change in github/Automattic/wp-desktop#765.

From desktop config.yml:

Payload -- success

```
 -d '{
              "payload": {
                "outcome": "'"success"'",
                "status": "'"success"'",
                "branch": "'"$BRANCHNAME"'",
                "build_url": "'"$CIRCLE_BUILD_URL"'",
                "build_parameters": {
                  "build_num": '"$CIRCLE_BUILD_NUM"',
                  "sha": "'"$sha"'",
                  "calypsoProject": "'"$calypsoProject"'"
                }
              }
```

Payload -- failure

```
 -d '{
          "payload": {
            "outcome": "'"failed"'",
            "status": "'"failed"'",
            "branch": "'"$BRANCHNAME"'",
            "build_url": "'"$CIRCLE_BUILD_URL"'",
            "build_parameters": {
              "build_num": '"$CIRCLE_BUILD_NUM"',
              "sha": "'"$sha"'",
              "calypsoProject": "'"$calypsoProject"'"
            }
```

Searching for the parameter `pullRequestNum` seems to indicate it is unused in wp-desktop's config.yml file and the rest of the desktop codebase.