### PR TITLE
Set isCalypsoCanaryRun to true when we trigger runs

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,8 @@ handler.on( 'pull_request', function ( event ) {
                 parameters: {
                     sha: sha,
                     CALYPSO_HASH: sha,
-                    calypsoProject: calypsoProject
+                    calypsoProject: calypsoProject,
+                    isCalypsoCanaryRun: true
                 }
             };
             // POST to CircleCI to initiate the build


### PR DESCRIPTION
This PR sets the new isCalypsoCanaryRun parameter to true when we trigger the CircleCI workflow. This will make it run the `calypso-canary` workflow in the WP-Desktop repo.