### PR TITLE
ensure created branch has unique SHA

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ handler.on( 'pull_request', function ( event ) {
                                     message: `create canary patch for ${wpDesktopBranchName}`,
                                     branch: `${wpDesktopBranchName}`,
                                     content: Buffer.from(makeRandom(20)).toString('base64'), // patch needs to be base64-encoded
-                                }
+                                };
 
                                 request.put({
                                     headers: { Authorization: 'token ' + process.env.GITHUB_SECRET, 'User-Agent': 'wp-desktop-gh-bridge' },
@@ -269,7 +269,7 @@ handler.on( 'pull_request', function ( event ) {
                                     .then(function (response) {
                                         if (response.statusCode === 201) {
                                             const desktopBranchSha = JSON.parse(response.body).commit.sha;
-                                            log.info( `Branch '{wpDesktopBranchName}' patched with SHA: ${desktopBranchSha}`);
+                                            log.info( `Branch '${wpDesktopBranchName}' patched with SHA: ${desktopBranchSha}`);
                                         } else {
                                             log.error( 'ERROR: Unable to patch new branch. Failed with error: ' + response.body );
                                         }


### PR DESCRIPTION
### Description

This PR ensures that each created branch has a unique SHA from develop. This is to minimize the interference of CI status and cancellations between branches.

Fixes: #19 